### PR TITLE
Implementing required changes

### DIFF
--- a/docs/01_set_up_dev_env/0102.md
+++ b/docs/01_set_up_dev_env/0102.md
@@ -16,10 +16,10 @@ If developers are working on multiple projects, they may even have challenges wi
 If you do want to try to create a custom image, look for the stretch goal solution sections within Exercise 1.
 
 1. Create a compute gallery & add it to the Dev center
-2. Create a custom image using Windows 11 Enterprise, version 22H2 - x64 Gen2
+2. Create a custom image using **Windows 11 Enterprise, version 22H2 - x64 Gen2**
 
    {: .note }
-   > Make sure you select enterprise and not pro. Pro is not supported for Dev Box.
+   > Make sure you select **Enterprise** and not pro. Pro is not supported for Dev Box.
 
 3. Include the following software on the custom image. If you have any issues selecting and copying the link you can also right click the link and select "Copy Link".
 4. Before running sysprep, shut down the VM and take a snapshot. Before running sysprep, shut down the VM and take a snapshot. Once you have a snapshot, boot the VM back up, login and run sysprep on the VM. Once you perform a sysprep you can't start the VM back up again without using this snapshot. Once you perform a sysprep you can't start the VM back up again without using this snapshot.
@@ -49,7 +49,7 @@ If you do want to try to create a custom image, look for the stretch goal soluti
 
 ## Tips
 
-- For the image creation, use the VM Size: Standard D4s v3 (4 vCPUs, 16 GiB memory) with a Windows 10 or 11 Image
+- For the image creation, use the VM Size: Standard D4s v5 (4 vCPUs, 16 GiB memory) with a **Windows 11 Enterprise, version 22H2 - x64 Gen2** Image
 - After running sysprep on a virtual machine in Azure, you can't use it again, so you can delete the VM along with it's associated resources (NIC, Disk, etc.)
 - For security, once you create the VM with RDP access, go into the networking settings and set the RDP access Source to be limited to your IP address
 - If you do need to make changes to your VM after you ran sysprep, you'll need to restore from the snapshot
@@ -68,7 +68,7 @@ If you do want to try to create a custom image, look for the stretch goal soluti
    ![Azure Compute Gallery](../../Media/AzureComputeGallery.png)
 2. Configure the following properties. On the Sharing Tab you can keep the defaults. Create the Gallery.
    ![Compute Gallery Configuration](../../Media/ComputerGalleryBasics.png)
-3. Now creating a Windows 11 VM
+3. Now creating a **Windows 11 Enterprise, version 22H2 - x64 Gen2** VM
    ![Create a Virtual Machine](../../Media/VirtualMachine.png)
 4. For the settings
     - Basics:
@@ -80,7 +80,7 @@ If you do want to try to create a custom image, look for the stretch goal soluti
         - **Note: Make sure you select enterprise and not pro. Pro is not supported for Dev Box. If you don't see Enterprise as an option. Select the link to see all images. The Select option under Microsoft Windows 11 will give you the option to select Windows 11 Enterprise, version 22H2 - x64 Gen2.**
       - Size: Standard_D4s_v5
       - Username: DevBoxAdmin
-      - Password: something you'll remember
+      - Password: *something you'll remember*
       - Licensing: Confirm
         ![Virtual Machine Basics](../../Media/VMBasics.png)
     - Disks:
@@ -103,8 +103,8 @@ If you do want to try to create a custom image, look for the stretch goal soluti
     - Java (for JMeter):
       - [https://www.java.com/en/download/](https://www.java.com/en/download/)
     - Apache JMeter:
-      - [https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.2.zip](https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.2.zip)
-      - Extract the apache-jmeter-5.6.2 folder to C:\
+      - [https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.3.zip](https://dlcdn.apache.org//jmeter/binaries/apache-jmeter-5.6.3.zip)
+      - Extract the apache-jmeter-5.6.3 folder to C:\
     - Azure Storage Explorer (Install for all users):
       - [https://azure.microsoft.com/products/storage/storage-explorer/](https://azure.microsoft.com/products/storage/storage-explorer/)
     - Git bash:

--- a/docs/01_set_up_dev_env/0103.md
+++ b/docs/01_set_up_dev_env/0103.md
@@ -61,7 +61,7 @@ Log into a dev box and configure any nessesary software to be able to use that i
     ![Create a dev box](../../Media/0102_CreateDevBox.png)
 3. Create a new dev box definition with the following settings and select Create.
      - Name: "TechExcel-Dev-Box"
-     - Image: Windows 11 Enterprise + OS Optimizations 23H2
+     - Image: Windows 11 Enterprise + OS Optimizations 22H2
      - Image version: Latest
      - Compute: 8vCPU, 32 GB RAM
      - Storage: 256 GB SSD


### PR DESCRIPTION
This pull request primarily involves updates to the documentation in the `docs/01_set_up_dev_env` directory. The changes emphasize the use of the **Windows 11 Enterprise, version 22H2 - x64 Gen2** image for custom VM creation, update the recommended VM size, and update the version of Apache JMeter to be installed. Additionally, minor formatting changes have been made for emphasis and clarity.

Major changes:

* [`docs/01_set_up_dev_env/0102.md`](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L19-R22): Updated the instructions for creating a custom image to specifically use **Windows 11 Enterprise, version 22H2 - x64 Gen2**. The changes also include formatting updates to emphasize key points. [[1]](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L19-R22) [[2]](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L52-R52) [[3]](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L71-R71) [[4]](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L83-R83)
* [`docs/01_set_up_dev_env/0102.md`](diffhunk://#diff-c564a3de0a0d26595a84fee1d1580fc720ebd4076a98c5a11ed3eb378a1e86e4L106-R107): Updated the link and instructions for installing Apache JMeter from version 5.6.2 to version 5.6.3.
* [`docs/01_set_up_dev_env/0103.md`](diffhunk://#diff-08c99d136aa089f20abfead378bd3c4451fc59a77b5359089210c2a936c0fd72L64-R64): Updated the recommended image for creating a new dev box definition.